### PR TITLE
Return `null` from `CloneBayUserService.findById` if authenticated user is not found

### DIFF
--- a/lib/src/api/clone-bay-user.service.ts
+++ b/lib/src/api/clone-bay-user.service.ts
@@ -13,7 +13,10 @@ export class CloneBayUserService {
 
   async findById(userId: string): Promise<User | null> {
     const user = await this.userService.findById(userId);
-    return user?.toObject();
+    if (!user) {
+      return null;
+    }
+    return user.toObject();
   }
 
   /**


### PR DESCRIPTION
Fixes #44.