### PR TITLE
Remove git SHA from links to source code

### DIFF
--- a/docs/src/api/classes/AuthenticationGuard.md
+++ b/docs/src/api/classes/AuthenticationGuard.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[lib/src/authentication/authentication.guard.ts:9](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/authentication/authentication.guard.ts#L9)
+[lib/src/authentication/authentication.guard.ts:9](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/authentication/authentication.guard.ts#L9)
 
 ## Methods
 
@@ -47,4 +47,4 @@ CanActivate.canActivate
 
 #### Defined in
 
-[lib/src/authentication/authentication.guard.ts:14](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/authentication/authentication.guard.ts#L14)
+[lib/src/authentication/authentication.guard.ts:14](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/authentication/authentication.guard.ts#L14)

--- a/docs/src/api/classes/CloneBayConfigService.md
+++ b/docs/src/api/classes/CloneBayConfigService.md
@@ -23,7 +23,7 @@ Get current dynamic configuration.
 
 #### Defined in
 
-[lib/src/api/clone-bay-config.service.ts:29](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-config.service.ts#L29)
+[lib/src/api/clone-bay-config.service.ts:29](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-config.service.ts#L29)
 
 ___
 
@@ -48,7 +48,7 @@ alliance included in this allowlist.
 
 #### Defined in
 
-[lib/src/api/clone-bay-config.service.ts:65](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-config.service.ts#L65)
+[lib/src/api/clone-bay-config.service.ts:65](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-config.service.ts#L65)
 
 ___
 
@@ -73,7 +73,7 @@ allowlist.
 
 #### Defined in
 
-[lib/src/api/clone-bay-config.service.ts:41](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-config.service.ts#L41)
+[lib/src/api/clone-bay-config.service.ts:41](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-config.service.ts#L41)
 
 ___
 
@@ -98,4 +98,4 @@ corporation included in this allowlist.
 
 #### Defined in
 
-[lib/src/api/clone-bay-config.service.ts:53](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-config.service.ts#L53)
+[lib/src/api/clone-bay-config.service.ts:53](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-config.service.ts#L53)

--- a/docs/src/api/classes/CloneBayEsiApiService.md
+++ b/docs/src/api/classes/CloneBayEsiApiService.md
@@ -36,7 +36,7 @@ See [EsiApiRequestOptions](../interfaces/EsiApiRequestOptions.md) for method par
 
 #### Defined in
 
-[lib/src/api/clone-bay-esi-api.service.ts:39](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-esi-api.service.ts#L39)
+[lib/src/api/clone-bay-esi-api.service.ts:39](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-esi-api.service.ts#L39)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[lib/src/api/clone-bay-esi-api.service.ts:27](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-esi-api.service.ts#L27)
+[lib/src/api/clone-bay-esi-api.service.ts:27](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-esi-api.service.ts#L27)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[lib/src/api/clone-bay-esi-api.service.ts:31](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-esi-api.service.ts#L31)
+[lib/src/api/clone-bay-esi-api.service.ts:31](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-esi-api.service.ts#L31)
 
 ___
 
@@ -114,4 +114,4 @@ ___
 
 #### Defined in
 
-[lib/src/api/clone-bay-esi-api.service.ts:35](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-esi-api.service.ts#L35)
+[lib/src/api/clone-bay-esi-api.service.ts:35](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-esi-api.service.ts#L35)

--- a/docs/src/api/classes/CloneBayMockingService.md
+++ b/docs/src/api/classes/CloneBayMockingService.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[lib/src/api/clone-bay-mocking.service.ts:10](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-mocking.service.ts#L10)
+[lib/src/api/clone-bay-mocking.service.ts:10](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-mocking.service.ts#L10)
 
 ## Methods
 
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[lib/src/api/clone-bay-mocking.service.ts:12](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-mocking.service.ts#L12)
+[lib/src/api/clone-bay-mocking.service.ts:12](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-mocking.service.ts#L12)
 
 ___
 
@@ -59,4 +59,4 @@ ___
 
 #### Defined in
 
-[lib/src/api/clone-bay-mocking.service.ts:16](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-mocking.service.ts#L16)
+[lib/src/api/clone-bay-mocking.service.ts:16](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-mocking.service.ts#L16)

--- a/docs/src/api/classes/CloneBayModule.md
+++ b/docs/src/api/classes/CloneBayModule.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[lib/src/clone-bay.module.ts:19](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/clone-bay.module.ts#L19)
+[lib/src/clone-bay.module.ts:19](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/clone-bay.module.ts#L19)
 
 ___
 
@@ -42,4 +42,4 @@ ___
 
 #### Defined in
 
-[lib/src/clone-bay.module.ts:11](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/clone-bay.module.ts#L11)
+[lib/src/clone-bay.module.ts:11](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/clone-bay.module.ts#L11)

--- a/docs/src/api/classes/CloneBayUserService.md
+++ b/docs/src/api/classes/CloneBayUserService.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[lib/src/api/clone-bay-user.service.ts:9](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-user.service.ts#L9)
+[lib/src/api/clone-bay-user.service.ts:9](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-user.service.ts#L9)
 
 ## Methods
 
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[lib/src/api/clone-bay-user.service.ts:14](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-user.service.ts#L14)
+[lib/src/api/clone-bay-user.service.ts:14](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-user.service.ts#L14)
 
 ___
 
@@ -63,4 +63,4 @@ Throws if the user is not found.
 
 #### Defined in
 
-[lib/src/api/clone-bay-user.service.ts:23](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/api/clone-bay-user.service.ts#L23)
+[lib/src/api/clone-bay-user.service.ts:23](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/api/clone-bay-user.service.ts#L23)

--- a/docs/src/api/classes/DynamicConfig.md
+++ b/docs/src/api/classes/DynamicConfig.md
@@ -29,7 +29,7 @@ _Default: `true`_
 
 #### Defined in
 
-[lib/src/config/dynamic-config.model.ts:31](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/config/dynamic-config.model.ts#L31)
+[lib/src/config/dynamic-config.model.ts:31](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/config/dynamic-config.model.ts#L31)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[lib/src/config/dynamic-config.model.ts:16](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/config/dynamic-config.model.ts#L16)
+[lib/src/config/dynamic-config.model.ts:16](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/config/dynamic-config.model.ts#L16)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[lib/src/config/dynamic-config.model.ts:10](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/config/dynamic-config.model.ts#L10)
+[lib/src/config/dynamic-config.model.ts:10](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/config/dynamic-config.model.ts#L10)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[lib/src/config/dynamic-config.model.ts:13](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/config/dynamic-config.model.ts#L13)
+[lib/src/config/dynamic-config.model.ts:13](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/config/dynamic-config.model.ts#L13)
 
 ___
 
@@ -80,4 +80,4 @@ _Default: `false`_
 
 #### Defined in
 
-[lib/src/config/dynamic-config.model.ts:46](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/config/dynamic-config.model.ts#L46)
+[lib/src/config/dynamic-config.model.ts:46](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/config/dynamic-config.model.ts#L46)

--- a/docs/src/api/classes/EveAccessToken.md
+++ b/docs/src/api/classes/EveAccessToken.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[lib/src/types/eve-access-token.dto.ts:9](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/eve-access-token.dto.ts#L9)
+[lib/src/types/eve-access-token.dto.ts:9](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/eve-access-token.dto.ts#L9)
 
 ___
 
@@ -28,4 +28,4 @@ ___
 
 #### Defined in
 
-[lib/src/types/eve-access-token.dto.ts:6](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/eve-access-token.dto.ts#L6)
+[lib/src/types/eve-access-token.dto.ts:6](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/eve-access-token.dto.ts#L6)

--- a/docs/src/api/classes/InvalidConfigurationException.md
+++ b/docs/src/api/classes/InvalidConfigurationException.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[lib/src/exceptions/invalid-configuration.exception.ts:8](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/exceptions/invalid-configuration.exception.ts#L8)
+[lib/src/exceptions/invalid-configuration.exception.ts:8](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/exceptions/invalid-configuration.exception.ts#L8)
 
 ## Methods
 

--- a/docs/src/api/classes/User.md
+++ b/docs/src/api/classes/User.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[lib/src/entities/user/user.model.ts:25](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/entities/user/user.model.ts#L25)
+[lib/src/entities/user/user.model.ts:25](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/entities/user/user.model.ts#L25)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[lib/src/entities/user/user.model.ts:21](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/entities/user/user.model.ts#L21)
+[lib/src/entities/user/user.model.ts:21](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/entities/user/user.model.ts#L21)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/src/entities/user/user.model.ts:12](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/entities/user/user.model.ts#L12)
+[lib/src/entities/user/user.model.ts:12](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/entities/user/user.model.ts#L12)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[lib/src/entities/user/user.model.ts:16](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/entities/user/user.model.ts#L16)
+[lib/src/entities/user/user.model.ts:16](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/entities/user/user.model.ts#L16)

--- a/docs/src/api/enums/UserAction.md
+++ b/docs/src/api/enums/UserAction.md
@@ -8,7 +8,7 @@
 
 #### Defined in
 
-[lib/src/authorization/user-action.enum.ts:3](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/authorization/user-action.enum.ts#L3)
+[lib/src/authorization/user-action.enum.ts:3](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/authorization/user-action.enum.ts#L3)
 
 ___
 
@@ -18,7 +18,7 @@ ___
 
 #### Defined in
 
-[lib/src/authorization/user-action.enum.ts:6](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/authorization/user-action.enum.ts#L6)
+[lib/src/authorization/user-action.enum.ts:6](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/authorization/user-action.enum.ts#L6)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[lib/src/authorization/user-action.enum.ts:2](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/authorization/user-action.enum.ts#L2)
+[lib/src/authorization/user-action.enum.ts:2](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/authorization/user-action.enum.ts#L2)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[lib/src/authorization/user-action.enum.ts:4](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/authorization/user-action.enum.ts#L4)
+[lib/src/authorization/user-action.enum.ts:4](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/authorization/user-action.enum.ts#L4)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[lib/src/authorization/user-action.enum.ts:5](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/authorization/user-action.enum.ts#L5)
+[lib/src/authorization/user-action.enum.ts:5](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/authorization/user-action.enum.ts#L5)

--- a/docs/src/api/functions/RequireAuthentication.md
+++ b/docs/src/api/functions/RequireAuthentication.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[lib/src/decorators/require-authentication.decorator.ts:4](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/decorators/require-authentication.decorator.ts#L4)
+[lib/src/decorators/require-authentication.decorator.ts:4](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/decorators/require-authentication.decorator.ts#L4)

--- a/docs/src/api/functions/RequirePolicies.md
+++ b/docs/src/api/functions/RequirePolicies.md
@@ -35,4 +35,4 @@
 
 #### Defined in
 
-[lib/src/decorators/require-policies.decorator.ts:6](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/decorators/require-policies.decorator.ts#L6)
+[lib/src/decorators/require-policies.decorator.ts:6](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/decorators/require-policies.decorator.ts#L6)

--- a/docs/src/api/functions/UserId.md
+++ b/docs/src/api/functions/UserId.md
@@ -14,4 +14,4 @@
 
 #### Defined in
 
-[lib/src/decorators/user-id.decorator.ts:5](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/decorators/user-id.decorator.ts#L5)
+[lib/src/decorators/user-id.decorator.ts:5](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/decorators/user-id.decorator.ts#L5)

--- a/docs/src/api/interfaces/CloneBayModuleOptions.md
+++ b/docs/src/api/interfaces/CloneBayModuleOptions.md
@@ -10,7 +10,7 @@ URL whereto redirect user after successful login.
 
 #### Defined in
 
-[lib/src/clone-bay-module-options.interface.ts:10](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/clone-bay-module-options.interface.ts#L10)
+[lib/src/clone-bay-module-options.interface.ts:10](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/clone-bay-module-options.interface.ts#L10)
 
 ___
 
@@ -26,7 +26,7 @@ their dynamic counterparts.
 
 #### Defined in
 
-[lib/src/clone-bay-module-options.interface.ts:30](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/clone-bay-module-options.interface.ts#L30)
+[lib/src/clone-bay-module-options.interface.ts:30](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/clone-bay-module-options.interface.ts#L30)
 
 ___
 
@@ -44,4 +44,4 @@ via `nestjs-eve-auth` options.
 
 #### Defined in
 
-[lib/src/clone-bay-module-options.interface.ts:21](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/clone-bay-module-options.interface.ts#L21)
+[lib/src/clone-bay-module-options.interface.ts:21](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/clone-bay-module-options.interface.ts#L21)

--- a/docs/src/api/interfaces/EsiApiRequestOptions.md
+++ b/docs/src/api/interfaces/EsiApiRequestOptions.md
@@ -16,7 +16,7 @@ who it belongs to!**
 
 #### Defined in
 
-[lib/src/types/esi-api-request-options.interface.ts:52](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/esi-api-request-options.interface.ts#L52)
+[lib/src/types/esi-api-request-options.interface.ts:52](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/esi-api-request-options.interface.ts#L52)
 
 ___
 
@@ -30,7 +30,7 @@ Default `false`. **Disabling this may cause tokens to leak!**
 
 #### Defined in
 
-[lib/src/types/esi-api-request-options.interface.ts:42](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/esi-api-request-options.interface.ts#L42)
+[lib/src/types/esi-api-request-options.interface.ts:42](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/esi-api-request-options.interface.ts#L42)
 
 ___
 
@@ -44,7 +44,7 @@ Authorization header is automatically appended to this.
 
 #### Defined in
 
-[lib/src/types/esi-api-request-options.interface.ts:36](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/esi-api-request-options.interface.ts#L36)
+[lib/src/types/esi-api-request-options.interface.ts:36](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/esi-api-request-options.interface.ts#L36)
 
 ___
 
@@ -57,7 +57,7 @@ authenticate the request.
 
 #### Defined in
 
-[lib/src/types/esi-api-request-options.interface.ts:11](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/esi-api-request-options.interface.ts#L11)
+[lib/src/types/esi-api-request-options.interface.ts:11](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/esi-api-request-options.interface.ts#L11)
 
 ___
 
@@ -69,7 +69,7 @@ Data payload for POST and PUT requests.
 
 #### Defined in
 
-[lib/src/types/esi-api-request-options.interface.ts:30](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/esi-api-request-options.interface.ts#L30)
+[lib/src/types/esi-api-request-options.interface.ts:30](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/esi-api-request-options.interface.ts#L30)
 
 ___
 
@@ -85,7 +85,7 @@ accidental token leaks. This behavior can be disabled with
 
 #### Defined in
 
-[lib/src/types/esi-api-request-options.interface.ts:19](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/esi-api-request-options.interface.ts#L19)
+[lib/src/types/esi-api-request-options.interface.ts:19](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/esi-api-request-options.interface.ts#L19)
 
 ___
 
@@ -100,4 +100,4 @@ belonging to them. Can be turned off with `allowAnyCharacter`.
 
 #### Defined in
 
-[lib/src/types/esi-api-request-options.interface.ts:26](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/types/esi-api-request-options.interface.ts#L26)
+[lib/src/types/esi-api-request-options.interface.ts:26](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/types/esi-api-request-options.interface.ts#L26)

--- a/docs/src/api/types/UserAbility.md
+++ b/docs/src/api/types/UserAbility.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[lib/src/authorization/ability.factory.ts:15](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/authorization/ability.factory.ts#L15)
+[lib/src/authorization/ability.factory.ts:15](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/authorization/ability.factory.ts#L15)

--- a/docs/src/api/variables/CLONE_BAY_MODULE_NAME.md
+++ b/docs/src/api/variables/CLONE_BAY_MODULE_NAME.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[lib/src/constants.ts:8](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/constants.ts#L8)
+[lib/src/constants.ts:8](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/constants.ts#L8)

--- a/docs/src/api/variables/CLONE_BAY_MODULE_OPTIONS_INJECTION_TOKEN.md
+++ b/docs/src/api/variables/CLONE_BAY_MODULE_OPTIONS_INJECTION_TOKEN.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[lib/src/constants.ts:4](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/constants.ts#L4)
+[lib/src/constants.ts:4](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/constants.ts#L4)

--- a/docs/src/api/variables/DYNAMIC_CONFIG_CACHE_KEY.md
+++ b/docs/src/api/variables/DYNAMIC_CONFIG_CACHE_KEY.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[lib/src/constants.ts:12](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/constants.ts#L12)
+[lib/src/constants.ts:12](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/constants.ts#L12)

--- a/docs/src/api/variables/USER_ID_KEY_IN_SESSION.md
+++ b/docs/src/api/variables/USER_ID_KEY_IN_SESSION.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[lib/src/constants.ts:16](https://github.com/joonashak/nestjs-clone-bay/blob/1a4ecf31d03284a98989ab940da71aae76589b7b/lib/src/constants.ts#L16)
+[lib/src/constants.ts:16](https://github.com/joonashak/nestjs-clone-bay/blob/main/lib/src/constants.ts#L16)

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -13,5 +13,6 @@
   "cleanOutputDir": true,
   "name": "API Reference",
   "allReflectionsHaveOwnDocument": true,
-  "groupOrder": ["Modules", "Services", "Guards", "Types", "Decorators", "Exceptions", "*"]
+  "groupOrder": ["Modules", "Services", "Guards", "Types", "Decorators", "Exceptions", "*"],
+  "sourceLinkTemplate": "https://github.com/joonashak/nestjs-clone-bay/blob/main/{path}#L{line}"
 }


### PR DESCRIPTION
Easier to work with the API docs generator when it does not change every file for each commit.